### PR TITLE
Added IE9 and Greater border radius in toast CSS.

### DIFF
--- a/src/main/resources/css/jquery.toastmessage.css
+++ b/src/main/resources/css/jquery.toastmessage.css
@@ -12,6 +12,7 @@
 	height: auto;
 	background: #333;
     opacity: 0.9;
+	border-radius: 10px;
 	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
 	color: #eee;


### PR DESCRIPTION
Toast CSS was missing "border-radius: 10px;". Added for better IE9 and
above support.
